### PR TITLE
Add 'cancel()' method to the throttled method wrapper (fix #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
+### Changed
+- Updated types to use generics; `throttle` will now return a function
+  of the same type it was passed.
+
 ### Fixed
 - Binding a throttled listener with `.bind()` resulted in both the bound and
   unbound listeners being throttled together.
@@ -18,10 +22,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   boundThrottledListener1();
   boundThrottledListener2();
   ```
-
-### Changed
-- Updated types to use generics; `throttle` will now return a function
-  of the same type it was passed.
 
 ## [2.0.1] - 2016-09-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
+### Added
+- Throttled listeners can now be canceled (useful for cleanup):
+  ```js
+  var throttledListener = throttle(listener);
+  window.addEventListener('resize', throttledListener);
+  submitButton.addEventListener('click', () => {
+    window.removeEventListener('resize', throttledListener);
+    // prevent any queued calls from executing on the next animation frame:
+    throttledListener.cancel();
+  })
+  ```
+
 ### Changed
 - Updated types to use generics; `throttle` will now return a function
   of the same type it was passed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Updated types to use generics; `throttle` will now return a function
   of the same type it was passed.
+- frame-throttle now runs in strict mode
 
 ### Fixed
 - Binding a throttled listener with `.bind()` resulted in both the bound and

--- a/README.md
+++ b/README.md
@@ -52,6 +52,46 @@ The callback will be called once during the next animation frame using
 then the callback will be called immediately, and `setTimeout` will be used to
 ignore further calls for 1/60th of a second.
 
+## Examples
+
+### `.cancel()`
+
+Throttled functions can be canceled, which is useful for cleaning up after
+yourself when you are no longer listening to an event.
+
+```js
+var throttledListener = throttle(listener);
+window.addEventListener('resize', throttledListener);
+submitButton.addEventListener('click', () => {
+    window.removeEventListener('resize', throttledListener);
+    // prevent any queued calls from executing on the next animation frame:
+    throttledListener.cancel();
+})
+```
+
+### Binding
+
+Throttled functions can be bound, and pass their context and args to your listener:
+
+```js
+// count the number of times that listener is called for each event type
+var counterObj = {
+    resize: 0,
+    scroll: 0,
+};
+var eventCounter = function (event) {
+    this[event] += 1;
+};
+var throttledCounter = throttle(eventCounter);
+window.addEventListener('resize', throttledCounter.bind(counterObj, 'resize'));
+window.addEventListener('scroll', throttledCounter.bind(counterObj, 'scroll'));
+```
+
+Each bound and unbound instance is throttled separately. This means that in the
+above example, if the resize and scroll events were fired within the same
+animation frame, both `counterObj.resize` and `counterObj.scroll` would be
+incremented.
+
 ## Gotchas
 
 ### Fallback to `setTimeout`

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ ignore further calls for 1/60th of a second.
 
 ## Gotchas
 
+### Fallback to `setTimeout`
+
 There is a slight difference in how `frame-throttle` works that depends on
 whether or not `requestAnimationFrame` exists.
 
@@ -71,6 +73,13 @@ a small possibility that the information you calculate your changes off of will
 be out of date by the time the next frame renders. The arguments to your callback
 will be the arguments of the first call to the throttled callback, and will
 be reset 1/60th of a second after the first call to the throttled callback.
+
+### `cancel()`
+
+`cancel()` cancels only the next scheduled run of the listener. If your
+throttled listener is called again after calling `cancel()`, your listener
+will be scheduled to run again during the next animation frame (or immediately
+if `window.requestAnimationFrame` does not exist.
 
 
 [travis-image]: https://travis-ci.org/pelotoncycle/frame-throttle.svg?branch=master

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To use _frame-throttle_, simply create your callback, and pass it to the
 pass to any method that would take your original callback,
 such as `addEventListener` and `removeEventListener`:
 
-```
+```js
 var throttle = require('frame-throttle').throttle;
 
 var callback = function(e) {
@@ -46,8 +46,8 @@ window.addEventListener('resize', throttledCallback);
 window.removeEventListener('resize', throttledCallback);
 ```
 
-You can use `throttle` to throttle any callback, not just event listeners.
-The callback will be called once during the next animation frame using
+You can use `throttle` to throttle any function, not just event listeners.
+The function will be called once during the next animation frame using
 `requestAnimationFrame` if it exists. If `requestAnimationFrame` does not exist,
 then the callback will be called immediately, and `setTimeout` will be used to
 ignore further calls for 1/60th of a second.
@@ -96,8 +96,8 @@ incremented.
 
 ### Fallback to `setTimeout`
 
-There is a slight difference in how `frame-throttle` works that depends on
-whether or not `requestAnimationFrame` exists.
+There are some slight differences in how `frame-throttle` behaves, depending on
+whether or not `window.requestAnimationFrame` exists.
 
 If `requestAnimationFrame` exists, then the callback will be called during the
 animation-frame callback section of the browser's next [browsing context event loop].

--- a/src/frame-throttle.ts
+++ b/src/frame-throttle.ts
@@ -39,10 +39,11 @@ const wrapperFactory = function (wrapperContext: any) {
     return wrapper as Cancellable<typeof wrapper>;
 };
 
-const throttleFactory = <T extends Function>(callback: T, thisArg?: any, ...argArray: any[]) => {
+const throttleFactory = function <T extends Function>(callback: T, thisArg?: any, ...argArray: any[]) {
     const wrapper = wrapperFactory({});
+    const argCount = arguments.length;
     const throttledCallback = function (...args: any[]) {
-        wrapper(thisArg || this, callback, ...argArray, ...args);
+        wrapper(argCount > 1 ? thisArg : this, callback, ...argArray, ...args);
     } as any as Cancellable<T>;
     throttledCallback.cancel = () => wrapper.cancel();
     return throttledCallback;

--- a/src/frame-throttle.ts
+++ b/src/frame-throttle.ts
@@ -1,6 +1,9 @@
 export type Cancellable<T extends Function>
     = T
     & {
+        /**
+         * Cancel the next scheduled invocation of the callback.
+         */
         cancel(): void;
     }
 

--- a/src/frame-throttle.ts
+++ b/src/frame-throttle.ts
@@ -4,42 +4,42 @@ export type Cancellable<T extends Function>
         cancel(): void;
     }
 
-export const throttle = <T extends Function>(callback: T): Cancellable<T> => {
-    const wrapperFactory = function (wrapperContext: any) {
-        const resetCancelToken = () => {
-            wrapperContext.cancelToken = false;
-        };
-
-        const wrapper = (cbThis: any, cb: T, ...args: any[]) => {
-            wrapperContext.callbackThis = cbThis;
-            wrapperContext.args = args;
-
-            if (wrapperContext.cancelToken) {
-                return;
-            }
-
-            if ('requestAnimationFrame' in window) {
-                wrapperContext.cancelToken = window.requestAnimationFrame(() => {
-                    cb.apply(wrapperContext.callbackThis, wrapperContext.args);
-                    resetCancelToken();
-                });
-            } else {
-                cb.apply(wrapperContext.callbackThis, wrapperContext.args);
-                wrapperContext.cancelToken = window.setTimeout(resetCancelToken, 1000 / 60); // 60 fps
-            }
-        };
-
-        (wrapper as Cancellable<typeof wrapper>).cancel = () => {
-            if ('requestAnimationFrame' in window) {
-                window.cancelAnimationFrame(wrapperContext.cancelToken);
-            }
-            window.clearTimeout(wrapperContext.cancelToken);
-            resetCancelToken();
-        };
-
-        return wrapper as Cancellable<typeof wrapper>;
+const wrapperFactory = function (wrapperContext: any) {
+    const resetCancelToken = () => {
+        wrapperContext.cancelToken = false;
     };
 
+    const wrapper = <T extends Function>(cbThis: any, cb: T, ...args: any[]) => {
+        wrapperContext.callbackThis = cbThis;
+        wrapperContext.args = args;
+
+        if (wrapperContext.cancelToken) {
+            return;
+        }
+
+        if ('requestAnimationFrame' in window) {
+            wrapperContext.cancelToken = window.requestAnimationFrame(() => {
+                cb.apply(wrapperContext.callbackThis, wrapperContext.args);
+                resetCancelToken();
+            });
+        } else {
+            cb.apply(wrapperContext.callbackThis, wrapperContext.args);
+            wrapperContext.cancelToken = window.setTimeout(resetCancelToken, 1000 / 60); // 60 fps
+        }
+    };
+
+    (wrapper as Cancellable<typeof wrapper>).cancel = () => {
+        if ('requestAnimationFrame' in window) {
+            window.cancelAnimationFrame(wrapperContext.cancelToken);
+        }
+        window.clearTimeout(wrapperContext.cancelToken);
+        resetCancelToken();
+    };
+
+    return wrapper as Cancellable<typeof wrapper>;
+};
+
+export const throttle = <T extends Function>(callback: T): Cancellable<T> => {
     const wrapper = wrapperFactory({});
     const throttledCallback = function (...args: any[]) {
         wrapper(this, callback, ...args);

--- a/src/frame-throttle.ts
+++ b/src/frame-throttle.ts
@@ -49,6 +49,13 @@ const throttleFactory = function <T extends Function>(callback: T, thisArg?: any
     return throttledCallback;
 };
 
+/**
+ * Returns a throttled function which runs once per rendered frame using
+ * requestAnimationFrame. If window.requestAnimationFrame does not exist,
+ * the behavior will be approximated using setTimeout.
+ *
+ * @param callback the function to be throttled
+ */
 export const throttle = <T extends Function>(callback: T): Cancellable<T> => {
     const throttledCallback = throttleFactory(callback);
 

--- a/src/tests/requestAnimationFrame.tests.ts
+++ b/src/tests/requestAnimationFrame.tests.ts
@@ -323,6 +323,26 @@ test('calling `.apply` passes the context and args to the listener', t => {
         'listener is called with the passed args');
 }, teardown);
 
+test('calling `.apply` with an undefined context passes the context and args to the listener', t => {
+    setup();
+    t.plan(2);
+
+    const listener = sinon.spy();
+    const throttledListener = throttle(listener);
+    const arg1 = {};
+    const arg2 = {};
+
+    throttledListener.apply(undefined, [arg1, arg2]);
+
+    mockRaf.step();
+
+    t.strictEquals(listener.getCall(0).thisValue, undefined,
+        'listener is called with the passed context');
+
+    t.true(listener.calledWithExactly(arg1, arg2),
+        'listener is called with the passed args');
+}, teardown);
+
 test('calling `.apply` passes the _latest_ context and args to the listener', t => {
     setup();
     t.plan(2);

--- a/src/tests/setTimeout.tests.ts
+++ b/src/tests/setTimeout.tests.ts
@@ -350,6 +350,24 @@ test('calling `.apply` passes the context and args to the listener', t => {
         'listener is called with the passed args');
 }, teardown);
 
+test('calling `.apply` with an undefined context passes the context and args to the listener', t => {
+    setup();
+    t.plan(2);
+
+    const listener = sinon.spy();
+    const throttledListener = throttle(listener);
+    const arg1 = {};
+    const arg2 = {};
+
+    throttledListener.apply(undefined, [arg1, arg2]);
+
+    t.strictEquals(listener.getCall(0).thisValue, undefined,
+        'listener is called with the passed context');
+
+    t.true(listener.calledWithExactly(arg1, arg2),
+        'listener is called with the passed args');
+}, teardown);
+
 test('calling `.apply` passes the _first_ context and args to the listener', t => {
     setup();
     t.plan(2);

--- a/src/tests/setTimeout.tests.ts
+++ b/src/tests/setTimeout.tests.ts
@@ -457,3 +457,55 @@ test('calling `.bind` followed by `.apply` correctly combines arguments', t => {
     t.deepEquals(listener.getCall(0).args, [argA1, argA2, argB1, argB2],
         'listener is called with the combined args');
 }, teardown);
+
+test('calling `cancel` cancels the wait', t => {
+    setup();
+    t.plan(1);
+
+    const listener = sinon.spy();
+    const throttledListener = throttle(listener);
+
+    throttledListener();
+
+    throttledListener.cancel();
+
+    throttledListener();
+
+    t.strictEqual(listener.callCount, 2,
+        'listener was called twice');
+}, teardown);
+
+test('calling `cancel` on a bound throttled listener does not cancel the original or others bound from it', t => {
+    setup();
+    t.plan(5);
+
+    const listener = sinon.spy();
+    const throttledListener = throttle(listener);
+    const context0 = {context: 0};
+    const context1 = {context: 1};
+    const context2 = {context: 1};
+    const boundThrottledListener1 = throttledListener.bind(context1);
+    const boundThrottledListener2 = throttledListener.bind(context2);
+
+    throttledListener.apply(context0);
+    boundThrottledListener1();
+    boundThrottledListener2();
+
+    boundThrottledListener1.cancel();
+
+    throttledListener.apply(context0);
+    boundThrottledListener1();
+    boundThrottledListener2();
+
+    t.strictEqual(listener.callCount, 4,
+        'listener was called four times');
+
+    t.strictEqual(listener.getCall(0).thisValue, context0,
+        'first call was from unbound throttled listener');
+    t.strictEqual(listener.getCall(1).thisValue, context1,
+        'second call was through first bound throttled listener');
+    t.strictEqual(listener.getCall(2).thisValue, context2,
+        'third call was through second bound throttled listener');
+    t.strictEqual(listener.getCall(3).thisValue, context1,
+        'fourth call was through first bound throttled listener');
+}, teardown);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
         "newLine": "LF",
         "noImplicitAny": true,
         "noImplicitReturns": true,
-        "noImplicitUseStrict": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "outDir": "./dist",


### PR DESCRIPTION
This is definitely not a good example of a single-purpose PR.

In addition to adding a `.cancel()` method off of the throttled method, this PR also:

* updates typescript typings to use generics
* updates the module to run in strict mode
* updates the README to add examples for canceling and binding
* adds some jsdoc comments to external methods

Fixes #3.